### PR TITLE
feat : 일기 검색 조건 추가(제목,내용,제목+내용)

### DIFF
--- a/server/src/main/java/com/codemouse/salog/diary/controller/DiaryController.java
+++ b/server/src/main/java/com/codemouse/salog/diary/controller/DiaryController.java
@@ -62,15 +62,16 @@ public class DiaryController {
         return new ResponseEntity<>(pageDiaries, HttpStatus.OK);
     }
 
-    // title list get
+    // 제목, 내용, 제목+내용 검색으로 일기 리스트 조회
     @GetMapping("/search")
-    public ResponseEntity<?> getTitleDiaries (@RequestHeader(name = "Authorization") String token,
-                                          @Positive @RequestParam int page,
-                                          @Positive @RequestParam int size,
-                                          @Valid @RequestParam String title){
+    public ResponseEntity<?> getSearchDiaries (@RequestHeader(name = "Authorization") String token,
+                                               @Positive @RequestParam int page,
+                                               @Positive @RequestParam int size,
+                                               @Valid @RequestParam String searchType,
+                                               @Valid @RequestParam String query){
 
         MultiResponseDto<DiaryDto.Response> pageDiaries =
-                diaryService.findTitleDiaries(token, page, size, title);
+                diaryService.findSearchDiaries(token, page, size, searchType, query);
 
         return new ResponseEntity<>(pageDiaries, HttpStatus.OK);
     }

--- a/server/src/main/java/com/codemouse/salog/diary/repository/DiaryRepository.java
+++ b/server/src/main/java/com/codemouse/salog/diary/repository/DiaryRepository.java
@@ -16,6 +16,8 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
     Page<Diary> findAllByMemberMemberIdAndDate(Long memberId, LocalDate date, Pageable pageable);
     Page<Diary> findAllByMemberMemberIdAndTitleContaining(long memberId, String title, Pageable pageRequest);
+    Page<Diary> findAllByMemberMemberIdAndBodyContaining(long memberId, String body, Pageable pageRequest);
+    Page<Diary> findAllByMemberMemberIdAndTitleContainingOrBodyContaining(long memberId, String title, String body,Pageable pageRequest);
 
     @Query("SELECT DISTINCT d.date FROM Diary d WHERE d.member.id = :memberId AND YEAR(d.date) = :year AND MONTH(d.date) = :month")
     List<LocalDate> findDistinctDatesByMemberIdAndYearAndMonth(@Param("memberId") Long memberId, @Param("year") int year, @Param("month") int month);

--- a/server/src/main/java/com/codemouse/salog/exception/ExceptionCode.java
+++ b/server/src/main/java/com/codemouse/salog/exception/ExceptionCode.java
@@ -26,6 +26,7 @@ public enum ExceptionCode {
     DIARY_NOT_FOUND(404, "DIARY_NOT_FOUND 존재하지 않는 일기"),
     TAG_NOT_FOUND(404, "TAG_NOT_FOUND 존재하지 않는 태그"),
     TAG_UNVALIDATED(400, "TAG_UNVALIDATED 유효하지않은 태그, 10글자이내로 입력바람"),
+    INVALID_SEARCH_TYPE(400, "INVALID_SEARCH_TYPE 유효하지 않은 검색 타입"),
 
     // 수입
     INCOME_NOT_FOUND(404, "INCOME_NOT_FOUND 존재하지 않는 수입"),


### PR DESCRIPTION
### PR 타입

1. [x] 기능 추가
2. [ ] 기능 삭제
3. [ ] 버그 수정
4. [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
1. 일기검색 api 파라미터 추가, 변경 (searchType은 title/ body/ title_body로 제한함)
기존의 'title' 파라미터를 'query'로 변수명 변경

2. 일기 레포 : 내용, 제목+내용으로 검색하는 쿼리 추가

3. 서비스 로직 : 위 내용에 해당하는 조건 분할

### 테스트 결과
